### PR TITLE
Fix typo in usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add these lines to your `theme.toml` configuration file to use it:
 
 ```toml
 [flavor]
-use = "kanagawa-dragon"
+dark = "kanagawa-dragon"
 ```
 
 ## 📜 License


### PR DESCRIPTION
The `use` key was split into `dark` and `light` in [v0.4.0](https://github.com/sxyazi/yazi/releases/tag/v0.4.0) by [this PR](https://github.com/sxyazi/yazi/pull/1946).

If you prefer, I'm happy to add a hint comment for pre-v0.4.0 installations like [this flavor does](https://github.com/BennyOe/tokyo-night.yazi?tab=readme-ov-file#%EF%B8%8F-usage), but other flavors are just migrating.